### PR TITLE
Updated BAP_composite in community example

### DIFF
--- a/python/RankComposites/utils_BAP.py
+++ b/python/RankComposites/utils_BAP.py
@@ -79,7 +79,7 @@ def calculate_distance_to_cloud_score(binary: openeo.DataCube,
         return np.ceil(f) // 2 * 2 + 1
     # Calculate dtc score
     kernel_size = round_up_to_odd(max_distance * 20 / spatial_resolution)  
-    gaussian_1d = gaussian(M=kernel_size, std=1)
+    gaussian_1d = gaussian(M=kernel_size, std=kernel_size/6)
     gaussian_kernel = np.outer(gaussian_1d, gaussian_1d)
     gaussian_kernel /= gaussian_kernel.sum()
     dtc_score = 1 - binary.apply_kernel(gaussian_kernel)


### PR DESCRIPTION
The STD in bap_composites util file is changed according to issue #81. 
Several STD's have been tested and kernelSize/6 seems appropriate. 

This change still needs to pushed to UDP of APEx. algorithm_catalog\vito\bap_composite\openeo_udp\bap_composite.json