### PR TITLE
fix: change ndvi-file extension from .tiff to .tif

### DIFF
--- a/python/LoadStac/load-stac-item-example.ipynb
+++ b/python/LoadStac/load-stac-item-example.ipynb
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -139,7 +139,7 @@
     }
    ],
    "source": [
-    "with rasterio.open(\"ndvi-file.tiff\") as src:\n",
+    "with rasterio.open(\"ndvi-file.tif\") as src:\n",
     "    show(src)"
    ]
   },


### PR DESCRIPTION
Hello community,

There’s a small typo in the notebook [python/LoadStac/load-stac-item-example.ipynb](https://github.com/Open-EO/openeo-community-examples/blob/main/python/LoadStac/load-stac-item-example.ipynb). The GeoTIFF path for `ndvi-file` should be `ndvi-file.tif` instead of `ndvi-file.tiff`.